### PR TITLE
Ft admin delete job 163570321 Adds the admin delete job endpoint

### DIFF
--- a/app/api/jobs/v1/models.py
+++ b/app/api/jobs/v1/models.py
@@ -101,4 +101,16 @@ class JobsModel():
             jobs[0]['location'] = location
             return jobs[0]
 
-        
+    def delete_job(self,id):
+        """
+        Method to allow admin to delete
+        """
+        if len(jobs) == 0:
+            return jobs
+        elif len(jobs) > 0:
+            for job in jobs:
+                if job['jobid'] == id:
+                    jobs.remove(job)
+                    # print(jobs)
+                    return True
+                return False

--- a/app/api/jobs/v1/models.py
+++ b/app/api/jobs/v1/models.py
@@ -51,6 +51,7 @@ class JobsModel():
         Method for retrieving all the books
         """
         return jobs
+
     def get_one(self,cat_id):
         """
         Method to retrieve one job
@@ -75,5 +76,29 @@ class JobsModel():
                     # return False
             #     return False
             # return False
+    
+    def get_job_by_id(self,id):
+        """
+        Method for checking if a job exists
+        """
+        for job in jobs:
+            if job['jobid'] == id:
+                return True
+            return False
+
+    def change_job_details(self,title,company,category,\
+                            responsibility,salary,location):
+        """
+        Method to allow change of job details
+        """
+        # job = self.get_one(id)
+        if len(jobs) > 0:
+            jobs[0]['title'] = title
+            jobs[0]['company'] = company
+            jobs[0]['category'] = category
+            jobs[0]['responsibility'] = responsibility
+            jobs[0]['salary'] = salary
+            jobs[0]['location'] = location
+            return jobs[0]
 
         

--- a/app/api/jobs/v1/views.py
+++ b/app/api/jobs/v1/views.py
@@ -20,6 +20,15 @@ job = api.model('Jobs',{
     'salary':fields.String(required=True,description='jobs salary')
 })
 
+job_edit = api.model('Edits',{
+    'new_title':fields.String(required=True,description='jobs title'),
+    'new_category':fields.String(required=True,description='jobs category'),
+    'new_responsibility':fields.String(required=True,description='jobs responsibility'),
+    'new_company':fields.Integer(required=True,description='jobs company'),
+    'new_location':fields.String(required=True,description='jobs location'),
+    'new_salary':fields.String(required=True,description='jobs salary')
+})
+
 class AddJob(Resource):
     """
     Class with methods to add/retrieve books
@@ -90,5 +99,56 @@ class GetJob(Resource):
                                                                     'job':get_job}]}), 200)
         return abort(make_response(jsonify({'message':'No job found'}),400))
 
+class EditJob(Resource):
+    """
+    Class with the method to edit a job
+    """
+    @api.expect(job_edit)
+    def put(self,id):
+        """
+        Method to edit a job
+        """
+        parser = reqparse.RequestParser()
+        parser.add_argument('new_title',type=str,\
+                            required=True,help='new_title field cannot be empty')
+        parser.add_argument('new_category',type=str,\
+                            required=True,help='new_category field cannot be empty')
+        parser.add_argument('new_responsibility',type=str,\
+                            required=True,help='new_responsibility field cannot be empty')
+        parser.add_argument('new_company',type=str,\
+                            required=True,help='new_company field cannot be empty')
+        parser.add_argument('new_location',type=str,\
+                            required=True,help='new_location field cannot be empty')
+        parser.add_argument('new_salary',type=str,\
+                            required=True,help='new_salary field cannot be empty')
+        args = parser.parse_args()
+        
+        if not validate_title(args['new_title']) or not check_space(args['new_title']):
+            return abort(make_response(jsonify({'message':'Invalid new_title'}),400))
+        # if not validate_category(args['new_category']) or not check_space(args['new_category']):
+        #     return abort(make_response(jsonify({'message':'Invalid new_category'}),400))
+        if not validate_responsibility(args['new_responsibility']) or not check_space(args['new_responsibility']):
+            return abort(make_response(jsonify({'message':'Invalid new_responsibility'}),400))
+        if not validate_company(args['new_company']) or not check_space(args['new_company']):
+            return abort(make_response(jsonify({'message':'Invalid new_company'}),400))
+        if not validate_location(args['new_location']) or not check_space(args['new_location']):
+            return abort(make_response(jsonify({'message':'Invalid new_location'}),400))
+        if not validate_salary(args['new_salary']):
+            return abort(make_response(jsonify({'message':'Invalid new_salary'}),400))
+        
+        check_job = JobsModel.get_job_by_id(self,id)
+        if not check_job:
+            return abort(make_response(jsonify({'message':'No job found'}),400))
+
+        response = JobsModel.change_job_details(self,title=args['new_title'],company=args['new_company'],category=args['new_category'],\
+                             responsibility=args['new_responsibility'],salary=args['new_salary'],\
+                             location=args['new_location'])
+        if response:
+            return  make_response(jsonify({"status": 200, "data": [{'message': 'job edited succesfully',
+                                                                    'job':response}]}), 200)
+       
+            
+
 api.add_resource(AddJob,'/jobs')
 api.add_resource(GetJob,'/jobs/<int:id>')
+api.add_resource(EditJob,'/jobs/edit/<int:id>')

--- a/app/api/jobs/v1/views.py
+++ b/app/api/jobs/v1/views.py
@@ -147,8 +147,23 @@ class EditJob(Resource):
             return  make_response(jsonify({"status": 200, "data": [{'message': 'job edited succesfully',
                                                                     'job':response}]}), 200)
        
-            
+class DeleteJob(Resource):
+    """
+    Class with method to remove a job
+    """        
+    def delete(self,id):
+        """
+        Method to remove a job
+        """
+        check_job = JobsModel.get_job_by_id(self,id)
+        if not check_job:
+            return abort(make_response(jsonify({'message':'No job found'}),400))
 
+        response = JobsModel.delete_job(self,id)
+        if response:
+            return  make_response(jsonify({"status": 200, "data": [{'message': 'job deleted succesfully'
+                                                                    }]}), 200)
 api.add_resource(AddJob,'/jobs')
 api.add_resource(GetJob,'/jobs/<int:id>')
 api.add_resource(EditJob,'/jobs/edit/<int:id>')
+api.add_resource(DeleteJob,'/jobs/delete/<int:id>')

--- a/app/tests/v1/test_base.py
+++ b/app/tests/v1/test_base.py
@@ -127,3 +127,12 @@ class BaseTest(unittest.TestCase):
             "location":"sembakasi",
             "salary":"10000"
         }
+        
+        self.edit_data = {
+            "new_title":"JrMedOfficer",
+            "new_category":"Medicine",
+            "new_responsibility":"sweep",
+            "new_company":"Dasani",
+            "new_location":"sembakasi",
+            "new_salary":"102000"
+        }

--- a/app/tests/v1/test_jobs_endpoints.py
+++ b/app/tests/v1/test_jobs_endpoints.py
@@ -50,5 +50,36 @@ class TestEndpoints(BaseTest):
         self.assertTrue(response.status_code, 200)
         self.assertIn(result['data'][0]['message'], 'jobs available')
 
+    def test_edit_job(self):
+        """
+        Method to test the editing a job
+        """
+        self.client.post('api/v1/jobs',\
+                          data=json.dumps(self.post_data2),\
+                          content_type='application/json')
+        response = self.client.put('api/v1/jobs/edit/1',\
+                         data=json.dumps(self.edit_data),\
+                        content_type='application/json')
+        result = json.loads(response.data)
+        # import pdb; pdb.set_trace()
+        self.assertTrue(response.status_code, 200)
+        self.assertIn(result['data'][0]['message'], 'job edited succesfully')
+
+    def test_delete_job(self):
+        """
+        Method to test the deletng a job
+        """
+        self.client.post('api/v1/jobs',\
+                          data=json.dumps(self.post_data2),\
+                          content_type='application/json')
+        response = self.client.delete('api/v1/jobs/delete/1',\
+                         data=json.dumps(self.edit_data),\
+                        content_type='application/json')
+        result = json.loads(response.data)
+        # import pdb; pdb.set_trace()
+        self.assertTrue(response.status_code, 200)
+        self.assertIn(result['data'][0]['message'], 'job deleted succesfully')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ Jinja2==2.10
 jsonschema==2.6.0
 MarkupSafe==1.1.0
 more-itertools==5.0.0
-pkg-resources==0.0.0
 pluggy==0.8.1
 py==1.7.0
 pytest==4.2.0


### PR DESCRIPTION
 #### What does this PR do?
It adds the `DELETE` endpoint that allows an admin to delete a job
 #### Description of Task to be completed?
Ensure the `DELETE` `/jobs/delete/<int:id>` work as expected
 #### How should this be manually tested?
Clone the repo to the local machine, cd into the folder, create a virtual env `python3 -m venv venv` then `pip install -r requirements.txt`. open Postman and test the endpoints
 #### Any background context you want to provide?
None
 #### What are the relevant pivotal tracker stories?
#163570321
 #### Screenshots (if appropriate)
 #### Questions: